### PR TITLE
Add required_ruby_version to gemspec

### DIFF
--- a/jsonb_accessor.gemspec
+++ b/jsonb_accessor.gemspec
@@ -4,20 +4,21 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "jsonb_accessor/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "jsonb_accessor"
-  spec.version       = JsonbAccessor::VERSION
-  spec.authors       = ["Michael Crismali", "Joe Hirn"]
-  spec.email         = ["michael.crismali@gmail.com", "joe@devmynd.com"]
+  spec.name                  = "jsonb_accessor"
+  spec.version               = JsonbAccessor::VERSION
+  spec.authors               = ["Michael Crismali", "Joe Hirn"]
+  spec.email                 = ["michael.crismali@gmail.com", "joe@devmynd.com"]
 
-  spec.summary       = %q{Adds typed jsonb backed fields to your ActiveRecord models.}
-  spec.description   = %q{Adds typed jsonb backed fields to your ActiveRecord models.}
-  spec.homepage      = "https://github.com/devmynd/jsonb_accessor"
-  spec.license       = "MIT"
+  spec.summary               = %q{Adds typed jsonb backed fields to your ActiveRecord models.}
+  spec.description           = %q{Adds typed jsonb backed fields to your ActiveRecord models.}
+  spec.homepage              = "https://github.com/devmynd/jsonb_accessor"
+  spec.license               = "MIT"
+  spec.required_ruby_version = '~> 2.0'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.files                 = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.bindir                = "exe"
+  spec.executables           = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.require_paths         = ["lib"]
 
   spec.add_dependency "activerecord", ">= 4.2.1"
   spec.add_dependency "pg"


### PR DESCRIPTION
The use of the double splat in lib/jsonb_accessor/macro.rb restricts the use of this gem to version 2x of ruby.