### PR TITLE
add a performance test

### DIFF
--- a/gemfiles/activerecord_4.2.1.gemfile.lock
+++ b/gemfiles/activerecord_4.2.1.gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: ../
   specs:
-    jsonb_accessor (0.3.1)
+    jsonb_accessor (0.3.2)
       activerecord (>= 4.2.1)
-      pg
+      pg (>= 0.18.1)
 
 GEM
   remote: https://rubygems.org/
@@ -59,7 +59,7 @@ GEM
       mini_portile (~> 0.6.0)
     parser (2.2.2.5)
       ast (>= 1.1, < 3.0)
-    pg (0.18.3)
+    pg (0.18.4)
     powerpack (0.1.1)
     pry (0.10.1)
       coderay (~> 1.1.0)
@@ -140,3 +140,6 @@ DEPENDENCIES
   rubocop (= 0.31.0)
   shoulda-matchers
   standalone_migrations
+
+BUNDLED WITH
+   1.11.2

--- a/gemfiles/activerecord_4.2.2.gemfile.lock
+++ b/gemfiles/activerecord_4.2.2.gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: ../
   specs:
-    jsonb_accessor (0.3.1)
+    jsonb_accessor (0.3.2)
       activerecord (>= 4.2.1)
-      pg
+      pg (>= 0.18.1)
 
 GEM
   remote: https://rubygems.org/
@@ -60,7 +60,7 @@ GEM
       mini_portile (~> 0.6.0)
     parser (2.3.0.pre.2)
       ast (>= 1.1, < 3.0)
-    pg (0.18.3)
+    pg (0.18.4)
     powerpack (0.1.1)
     pry (0.10.1)
       coderay (~> 1.1.0)
@@ -141,3 +141,6 @@ DEPENDENCIES
   rubocop (= 0.31.0)
   shoulda-matchers
   standalone_migrations
+
+BUNDLED WITH
+   1.11.2

--- a/gemfiles/activerecord_4.2.3.gemfile.lock
+++ b/gemfiles/activerecord_4.2.3.gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: ../
   specs:
-    jsonb_accessor (0.3.1)
+    jsonb_accessor (0.3.2)
       activerecord (>= 4.2.1)
-      pg
+      pg (>= 0.18.1)
 
 GEM
   remote: https://rubygems.org/
@@ -59,7 +59,7 @@ GEM
       mini_portile (~> 0.6.0)
     parser (2.2.3.0)
       ast (>= 1.1, < 3.0)
-    pg (0.18.3)
+    pg (0.18.4)
     powerpack (0.1.1)
     pry (0.10.3)
       coderay (~> 1.1.0)
@@ -140,3 +140,6 @@ DEPENDENCIES
   rubocop (= 0.31.0)
   shoulda-matchers
   standalone_migrations
+
+BUNDLED WITH
+   1.11.2

--- a/gemfiles/activerecord_4.2.4.gemfile.lock
+++ b/gemfiles/activerecord_4.2.4.gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: ../
   specs:
-    jsonb_accessor (0.3.1)
+    jsonb_accessor (0.3.2)
       activerecord (>= 4.2.1)
-      pg
+      pg (>= 0.18.1)
 
 GEM
   remote: https://rubygems.org/
@@ -59,7 +59,7 @@ GEM
       mini_portile (~> 0.6.0)
     parser (2.2.3.0)
       ast (>= 1.1, < 3.0)
-    pg (0.18.3)
+    pg (0.18.4)
     powerpack (0.1.1)
     pry (0.10.3)
       coderay (~> 1.1.0)
@@ -140,3 +140,6 @@ DEPENDENCIES
   rubocop (= 0.31.0)
   shoulda-matchers
   standalone_migrations
+
+BUNDLED WITH
+   1.11.2

--- a/jsonb_accessor.gemspec
+++ b/jsonb_accessor.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths         = ["lib"]
 
   spec.add_dependency "activerecord", ">= 4.2.1"
-  spec.add_dependency "pg"
+  spec.add_dependency "pg", ">= 0.18.1"
 
   spec.add_development_dependency "actionpack", "~> 4.2.1"
   spec.add_development_dependency "appraisal"

--- a/spec/jsonb_accessor_performance_spec.rb
+++ b/spec/jsonb_accessor_performance_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Jsonb Accessor Performace" do
       static_time = Benchmark.realtime { StaticProduct.all.to_a }
       jsonb_time = Benchmark.realtime { Product.all.to_a }
 
-      expect(static_time * 200).to be > jsonb_time
+      expect(static_time * 500).to be > jsonb_time
     end
   end
 end

--- a/spec/jsonb_accessor_performance_spec.rb
+++ b/spec/jsonb_accessor_performance_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Jsonb Accessor Performace" do
       static_time = Benchmark.realtime { StaticProduct.all.to_a }
       jsonb_time = Benchmark.realtime { Product.all.to_a }
 
-      expect(static_time * 100).to be > jsonb_time
+      expect(static_time * 200).to be > jsonb_time
     end
   end
 end

--- a/spec/jsonb_accessor_performance_spec.rb
+++ b/spec/jsonb_accessor_performance_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+
+RSpec.describe "Jsonb Accessor Performace" do
+  context "initializing objects from the database" do
+    before do
+      10.times do
+        Product.create(
+          string_type: "static string",
+          integer_type: (1..60_000).to_a.sample,
+          boolean_type: [true, false].sample,
+          float_type: rand,
+          time_type: Time.now,
+          date_type: Date.today
+        )
+      end
+    end
+
+    it "is of reasonable performance against non-jsonb records" do
+      static_time = Benchmark.realtime { StaticProduct.all.to_a }
+      jsonb_time = Benchmark.realtime { Product.all.to_a }
+
+      expect(static_time * 100).to be > jsonb_time
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,9 +48,13 @@ TYPED_FIELDS = {
 }
 ALL_FIELDS = VALUE_FIELDS + TYPED_FIELDS.keys
 
-class Product < ActiveRecord::Base
-  jsonb_accessor :options, *VALUE_FIELDS, TYPED_FIELDS
+class StaticProduct < ActiveRecord::Base
+  self.table_name = "products"
   belongs_to :product_category
+end
+
+class Product < StaticProduct
+  jsonb_accessor :options, *VALUE_FIELDS, TYPED_FIELDS
 end
 
 class OtherProduct < ActiveRecord::Base


### PR DESCRIPTION
This shows that jsonb_accessor is two orders of magnitude slower when retrieving records.

Also, the timing is a linear increase given the number of objects. In other words, changing it to 100 products to retrieve would fail the test.