### PR TITLE
Support for Rails 5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,5 @@ gemspec
 
 # Travis CI requires in Gemfile
 gem 'pg'
+gem 'activerecord', '~> 5.0'
+gem 'actionpack', '~> 5.0'

--- a/lib/jsonb_accessor/class_builder.rb
+++ b/lib/jsonb_accessor/class_builder.rb
@@ -65,7 +65,13 @@ module JsonbAccessor
             define_method(attribute_name) { attributes[attribute_name] }
 
             define_method("#{attribute_name}=") do |value|
-              cast_value = attributes_and_data_types[attribute_name].type_cast_from_user(value)
+              data_type = attributes_and_data_types[attribute_name]
+              cast_value = if data_type.respond_to?(:type_cast_from_user)
+                  data_type.type_cast_from_user(value)
+                else
+                  # active_model >= 5
+                  data_type.cast(value)
+                end
               attributes[attribute_name] = cast_value
               update_parent
             end

--- a/lib/jsonb_accessor/macro.rb
+++ b/lib/jsonb_accessor/macro.rb
@@ -53,7 +53,7 @@ module JsonbAccessor
           end
         end
 
-        after_initialize(jsonb_attribute_initialization_method_name)
+        after_initialize(jsonb_attribute_initialization_method_name.to_sym)
       end
 
       def _create_jsonb_attribute_scope_name(jsonb_attribute, jsonb_attribute_scope_name)
@@ -73,7 +73,7 @@ module JsonbAccessor
 
       def __create_jsonb_standard_scopes(fields_map, jsonb_attribute_scope_name)
         fields_map.names.each do |field|
-          scope "with_#{field}", -> (value) { send(jsonb_attribute_scope_name, field => value) }
+          scope "with_#{field}", -> (value) { send(jsonb_attribute_scope_name.to_sym, field => value) }
         end
       end
 

--- a/lib/jsonb_accessor/type_helper.rb
+++ b/lib/jsonb_accessor/type_helper.rb
@@ -19,8 +19,13 @@ module JsonbAccessor
       end
 
       def type_cast_as_jsonb(suspect)
-        type_cast_hash = jsonb.type_cast_from_user(suspect)
-        jsonb.type_cast_for_database(type_cast_hash)
+        if jsonb.respond_to?(:type_cast_from_user)
+          type_cast_hash = jsonb.type_cast_from_user(suspect)
+          jsonb.type_cast_for_database(type_cast_hash)
+        else
+          # active_model >= 5
+          jsonb.serialize(suspect)
+        end
       end
 
       private

--- a/spec/jsonb_accessor_spec.rb
+++ b/spec/jsonb_accessor_spec.rb
@@ -131,6 +131,15 @@ RSpec.describe JsonbAccessor do
   end
 
   context "typed setters" do
+
+    TRUE_VALUES = [true, 1, '1', 't', 'T', 'true', 'TRUE', 'on', 'ON']
+    FALSE_VALUES = if ActiveRecord::ConnectionAdapters::Column.const_defined?(:FALSE_VALUES)
+          ActiveRecord::ConnectionAdapters::Column::FALSE_VALUES
+        else
+          # active_record >= 5.0
+          ActiveModel::Type::Boolean::FALSE_VALUES
+        end
+
     subject { Product.new }
     let(:title) { "Mister" }
     let(:id_value) { 1056 }
@@ -235,14 +244,14 @@ RSpec.describe JsonbAccessor do
         expect(subject.options["admin"]).to eq(admin)
       end
 
-      ActiveRecord::ConnectionAdapters::Column::FALSE_VALUES.each do |value|
+      FALSE_VALUES.each do |value|
         it "coerces the value to false when the value is '#{value}'" do
           subject.admin = value
           expect(subject.admin).to eq(false)
         end
       end
 
-      ActiveRecord::ConnectionAdapters::Column::TRUE_VALUES.each do |value|
+      TRUE_VALUES.each do |value|
         it "coerces the value to true when the value is '#{value}'" do
           subject.admin = value
           expect(subject.admin).to eq(true)
@@ -407,14 +416,14 @@ RSpec.describe JsonbAccessor do
             expect(subject.options["favorited_history"]).to eq(favorited_history)
           end
 
-          ActiveRecord::ConnectionAdapters::Column::FALSE_VALUES.each do |value|
+          FALSE_VALUES.each do |value|
             it "coerces the value to false when the value is '#{value}'" do
               subject.favorited_history = [value]
               expect(subject.favorited_history).to eq([false])
             end
           end
 
-          ActiveRecord::ConnectionAdapters::Column::TRUE_VALUES.each do |value|
+          TRUE_VALUES.each do |value|
             it "coerces the value to true when the value is '#{value}'" do
               subject.favorited_history = [value]
               expect(subject.favorited_history).to eq([true])

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "jsonb_accessor"
+require "action_dispatch/middleware/executor"
 require "action_dispatch/middleware/reloader"
 require "pry"
 require "pry-nav"


### PR DESCRIPTION
Rails 5.0 introduces a few API changes that are affecting this gem's functionality.  Although most things still work under 5.0, that will change with 5.1 which drops legacy support as announced by the deprecation message:
````
DEPRECATION WARNING: Passing string to define callback is deprecated and will be removed in Rails 5.1 without replacement.
````
This pull request is not finished, still work in progress with 7 test failing at the moment. Most of them are caused by `type_cast_as_jsonb` where the replacement API methods do not exactly work like in 4.2. I'd like to get some feedback on the changes I have already made.