### PR TITLE
Clarify scope naming, it's not always `data_where`

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ class Product < ActiveRecord::Base
 end
 ```
 
-Jsonb Accessor will add a `scope` to `Product` called `data_where`.
+Jsonb Accessor will add a `scope` to `Product` called like the json column with `_where` suffix, in our case `data_where`.
 
 ```ruby
 Product.all.data_where(name: "Granite Towel", price: 17)


### PR DESCRIPTION
The readme should state that the scope's name depends on the column name provided to `jsonb_accessor` class method.