### PR TITLE
Support with indifferent access and fix nil behaviour

### DIFF
--- a/lib/jsonb_accessor.rb
+++ b/lib/jsonb_accessor.rb
@@ -2,6 +2,7 @@
 require "active_record"
 
 require "active_record/connection_adapters/postgresql_adapter"
+require "active_support/core_ext/hash/indifferent_access"
 
 require "jsonb_accessor/version"
 require "jsonb_accessor/macro"

--- a/lib/jsonb_accessor/macro.rb
+++ b/lib/jsonb_accessor/macro.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require 'active_support/core_ext/hash/indifferent_access'
+
 module JsonbAccessor
   module Macro
     module ClassMethods
@@ -56,6 +58,11 @@ module JsonbAccessor
               new_values = (public_send(jsonb_attribute) || {}).merge(store_key => public_send(name))
               write_attribute(jsonb_attribute, new_values)
             end
+          end
+
+          # # Overrides jsonb attribute getter with indifferent access
+          define_method("#{jsonb_attribute}") do
+            (super() || {}).with_indifferent_access
           end
 
           # Overrides the jsonb attribute setter to make sure the jsonb fields are kept in sync.

--- a/lib/jsonb_accessor/macro.rb
+++ b/lib/jsonb_accessor/macro.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
-require 'active_support/core_ext/hash/indifferent_access'
-
 module JsonbAccessor
   module Macro
     module ClassMethods
@@ -60,8 +58,8 @@ module JsonbAccessor
             end
           end
 
-          # # Overrides jsonb attribute getter with indifferent access
-          define_method("#{jsonb_attribute}") do
+          # Overrides jsonb attribute getter with indifferent access or empty hash
+          define_method(jsonb_attribute.to_s) do
             (super() || {}).with_indifferent_access
           end
 

--- a/spec/jsonb_accessor_spec.rb
+++ b/spec/jsonb_accessor_spec.rb
@@ -49,6 +49,13 @@ RSpec.describe JsonbAccessor do
     it "supports defaults" do
       expect(instance.bazzle).to eq(5)
     end
+
+    it "indifferent accessible" do
+      expect(instance.options).to be_a Hash
+
+      expect(instance.options["bazzle"]).to eq(5)
+      expect(instance.options[:bazzle]).to eq(5)
+    end
   end
 
   context "getters" do


### PR DESCRIPTION
Behaviour differs when returning nil vs empty hash. Having jsonb column attribute returning nil would raise an error when calling eg. `instance.options["foo"]`. Returning an empty hash keeps the behaviour constant - `instance.options["foo"] == nil`

I do find having `Hash#with_indifferent_access` incredibly helpful as well.

This is my first time contributing to opensauce so do let me know what I'm doing wrong! 
Loving this gem so far.