### PR TITLE
Allow procs for default values

### DIFF
--- a/spec/jsonb_accessor_spec.rb
+++ b/spec/jsonb_accessor_spec.rb
@@ -96,20 +96,18 @@ RSpec.describe JsonbAccessor do
     end
   end
 
-  # rubocop:disable GlobalVars
   context "defaults" do
     let(:klass) do
-      build_class(foo: [:string, default: "bar"], baz: [:integer, default: -> { $expected_default }])
+      counter = 0
+      build_class(foo: [:string, default: "bar"], baz: [:integer, default: -> { counter += 1 }])
     end
 
     it "allows defaults (literal and as proc)" do
-      $expected_default = 1
       expect(instance.foo).to eq("bar")
       expect(instance.baz).to eq(1)
       expect(instance.options).to eq("foo" => "bar", "baz" => 1)
 
       # Make sure the default proc is evaluated each time an instance is created
-      $expected_default = 2
       expect(klass.new.baz).to eq(2)
     end
 
@@ -126,19 +124,20 @@ RSpec.describe JsonbAccessor do
 
     context "inheritance" do
       let(:subklass) do
+        counter = 100
         Class.new(klass) do
-          jsonb_accessor :options, bazbaz: [:integer, default: -> { $expected_default }]
+          jsonb_accessor :options, bazbaz: [:integer, default: -> { counter += 1 }]
         end
       end
 
       it "allows procs as default values in both superclasses and subclasses" do
-        $expected_default = 1
-        expect(subklass.new.baz).to eq(1)
-        expect(subklass.new.bazbaz).to eq(1)
+        instance = subklass.new
+        expect(instance.baz).to eq(1)
+        expect(instance.bazbaz).to eq(101)
 
-        $expected_default = 2
-        expect(subklass.new.baz).to eq(2)
-        expect(subklass.new.bazbaz).to eq(2)
+        instance = subklass.new
+        expect(instance.baz).to eq(2)
+        expect(instance.bazbaz).to eq(102)
       end
     end
 
@@ -189,7 +188,6 @@ RSpec.describe JsonbAccessor do
       end
     end
   end
-  # rubocop:enable GlobalVars
 
   context "setting the jsonb field directly" do
     let(:klass) do


### PR DESCRIPTION
In principle, the attributes API supports default procs out of the box.

But we need to do some extra work because we’re not setting individual default values for each field but a “combined” default value for the jsonb column (see https://github.com/devmynd/jsonb_accessor/issues/57#issuecomment-286955899).

A note regarding the tests: I’m never really sure about the best approach for testing things like this. For now I decided to use a global variable because I think it’s the simplest way while still being quite intention revealing. If you prefer something else just let me know! (Using instance variables on the tested class  would also be possible, for example.)